### PR TITLE
Patch UUID tableprefix

### DIFF
--- a/src/Model/Behavior/ExposeBehavior.php
+++ b/src/Model/Behavior/ExposeBehavior.php
@@ -82,7 +82,7 @@ class ExposeBehavior extends Behavior {
 	 * @return string
 	 */
 	public function getExposedKey(): string {
-		return $this->getConfig('field');
+		return $this->_table->getAlias().'.'.$this->getConfig('field');
 	}
 
 	/**
@@ -96,7 +96,7 @@ class ExposeBehavior extends Behavior {
 	 * @throws \InvalidArgumentException If the 'slug' key is missing in options
 	 */
 	public function findExposed(Query $query, array $options) {
-		$field = $this->getConfig('field');
+		$field = $this->getExposedKey();
 		if (empty($options[$field])) {
 			throw new InvalidArgumentException('The `' . $field . '` key is required for find(\'exposed\')');
 		}

--- a/tests/TestCase/Model/Behavior/ExposeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ExposeBehaviorTest.php
@@ -161,7 +161,9 @@ class ExposeBehaviorTest extends TestCase {
 
 		$this->assertNotEmpty($user->uuid);
 
-		$result = $binaryFieldRecordsTable->find('exposed', ['uuid' => $user->uuid])->firstOrFail();
+		$field = $binaryFieldRecordsTable->getExposedKey();
+
+		$result = $binaryFieldRecordsTable->find('exposed', [$field => $user->uuid])->firstOrFail();
 		$this->assertSame($user->name, $result->name);
 	}
 


### PR DESCRIPTION
Fix the following:

A "exposed"-find with contain like this:
`public function edit($uuid = null)
{
  $field = $this->Customers->getExposedKey();
  $customer = $this->Customers->find('exposed', [$field => $uuid])->contain(['Addresses'])->firstOrFail();
  ...
}`

will cause the error "Column 'uuid' in where clause is ambiguous"
Looking at the SQL Log it is clear - no tablename before 'uuid':

`SELECT
  Customers.id AS Customers__id, 
  Customers.address_id AS Customers__address_id, 
  ...
  Customers.uuid AS Customers__uuid, 
  Addresses.id AS Addresses__id, 
  Addresses.organization AS Addresses__organization, 
  ...
  Addresses.uuid AS Addresses__uuid 
FROM 
  customers Customers 
  INNER JOIN addresses Addresses ON Addresses.id = (Customers.address_id) 
WHERE 
  uuid = '29f554bf-f703-4c9a-b777-69925c4064f9'
LIMIT 
  1 `
 
The fix will add the table prefix before 'uuid':
`
SELECT 
  Customers.id AS Customers__id, 
  Customers.address_id AS Customers__address_id, 
  ...
  Customers.uuid AS Customers__uuid, 
  Addresses.id AS Addresses__id, 
  Addresses.organization AS Addresses__organization, 
  ...
  Addresses.nation AS Addresses__nation, 
  Addresses.uuid AS Addresses__uuid 
FROM 
  customers Customers 
  INNER JOIN addresses Addresses ON Addresses.id = (Customers.address_id) 
WHERE 
  Customers.uuid = '29f554bf-f703-4c9a-b777-69925c4064f9' 
LIMIT 
  1
`