### PR TITLE
Short UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Robustness
 
 Simplicity
 - Code changes from AIID exposure to UUID lookup should be minimal for all public endpoints.
+- The default shortener provided makes the UUIDs also only 22 chars long concise strings.
 
 ### Why UUIDs
 This replaces [Hashid](https://github.com/dereuromark/cakephp-hashid) as a more explicit approach which has several advantages:
@@ -88,3 +89,5 @@ Faster than the speed of light:
 - After also executing that migration all new records will automatically have their exposed field stored as well.
 
 You are done and can now adjust your public actions to query by exposed field only and hide the primary key completely.
+Using `Superimpose` behavior on top of `Expose` means that you actually might not even have to modify any code.
+Should work out of the box.

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,8 @@
 		"cakephp/cakephp": "^4.0"
 	},
 	"require-dev": {
+		"ext-bcmath": "*",
+		"keiko/uuid-shortener": "^0.2.1",
 		"fig-r/psr2r-sniffer": "dev-master"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
 	},
 	"require-dev": {
 		"ext-bcmath": "*",
+		"brick/math": "^0.8.14",
 		"keiko/uuid-shortener": "^0.2.1",
 		"fig-r/psr2r-sniffer": "dev-master"
 	},

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,39 @@ Tip: Binary UUID saves a lot of disk space in the long run. Use `-b`/`--binary` 
 
 Then execute the migration using `bin/cake migrations migrate`.
 
+#### Shortening Converters
+If you also want to shorten the resulting output UUID from 32 to 22 chars, go with `ShortUuidType` class which extends the binary one.
+In this case you need to specify the type-map in your bootstrap:
+```php
+use Cake\Database\Type;
+
+Type::map('binaryuuid', \Expose\Database\Type\ShortUuidType::class);
+```
+A UUID stored in the DB as `4e52c919-513e-4562-9248-7dd612c6c1ca` would then be displayed and
+used as `fpfyRTmt6XeE9ehEKZ5LwF` for example.
+This can be a bit more user-friendly as it is shorter and selectable with a double click in most browsers and apps.
+
+Make sure to include the required composer dependencies as listed at the top of the converter class.
+For the default one to work you need to run
+```
+composer require brick/math
+```
+
+You can select a different converter than the default `Short` one by configuring it through `Expose.converter`:
+```php
+// e.g. in your app.php
+'Expose.converter' => \Expose\Converter\KeikoShort::class,
+```
+Or write your own one on plugin or app level using the given interface:
+```php
+namespace App\Converter;
+
+use Expose\Converter\ConverterInterface;
+
+class MyShort implements ConverterInterface {
+    // implement the methods
+}
+```
 
 #### Entity update
 You want to make sure that neither primary key, nor this exposed field is patchable (when marshalling = mass assignment):

--- a/src/Converter/ConverterInterface.php
+++ b/src/Converter/ConverterInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Expose\Converter;
+
+interface ConverterInterface {
+
+	/**
+	 * UUID to ShortUUID
+	 *
+	 * @param string $value
+	 *
+	 * @return string
+	 */
+	public function encode(string $value): string;
+
+	/**
+	 * Back from ShortUUID to UUID
+	 *
+	 * @param string $value
+	 *
+	 * @return string
+	 */
+	public function decode(string $value): string;
+
+}

--- a/src/Converter/KeikoShort.php
+++ b/src/Converter/KeikoShort.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Expose\Converter;
+
+use Keiko\Uuid\Shortener\Dictionary;
+use Keiko\Uuid\Shortener\Number\BigInt\Converter;
+use Keiko\Uuid\Shortener\Shortener;
+
+/**
+ * Make sure to include the required dependency `"keiko/uuid-shortener": "^0.2.1"`.
+ *
+ * @link https://github.com/mgrajcarek/uuid-shortener
+ */
+class KeikoShort implements ConverterInterface {
+
+	/**
+	 * @var \Keiko\Uuid\Shortener\Shortener
+	 */
+	protected $shortener;
+
+	/**
+	 * @param \Keiko\Uuid\Shortener\Dictionary|null $dictionary
+	 */
+	public function __construct(?Dictionary $dictionary = null) {
+		$this->shortener = new Shortener(
+			$dictionary ?: Dictionary::createUnmistakable(),
+			new Converter()
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function encode(string $value): string {
+		return $this->shortener->reduce($value);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function decode(string $value): string {
+		return $this->shortener->expand($value);
+	}
+
+}

--- a/src/Converter/Short.php
+++ b/src/Converter/Short.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Expose\Converter;
+
+use Brick\Math\BigInteger;
+use Brick\Math\RoundingMode;
+
+/**
+ * Make sure to include the required dependency `"brick/math": "^0.8.14"`.
+ *
+ * @link https://github.com/mgrajcarek/uuid-shortener
+ */
+class Short implements ConverterInterface {
+
+	/**
+	 * @var string[]
+	 */
+	protected $dictionary = [
+		'2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
+		'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
+		'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'm', 'n',
+		'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+	];
+
+	/**
+	 * @var int
+	 */
+	protected $dictionaryLength = 57;
+
+	/**
+	 * @param string[]|null $dictionary
+	 */
+	public function __construct(array $dictionary = null) {
+		if ($dictionary !== null) {
+			$this->dictionary = $dictionary;
+			$this->dictionaryLength = count($dictionary);
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function encode(string $value): string {
+		$value = str_replace('-', '', $value);
+		$uuidInteger = BigInteger::fromBase($value, 16);
+
+		return $this->numToString($uuidInteger);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function decode(string $value): string {
+		$uuidInteger = $this->stringToNum($value);
+		$uuidInteger = BigInteger::fromBase($uuidInteger, 10)->toBase(16);
+
+		return $this->formatHex($uuidInteger);
+	}
+
+	/**
+	 * Transforms a given (big) number to a string value, based on the set dictionary.
+	 *
+	 * @param \Brick\Math\BigInteger $number
+	 *
+	 * @return string
+	 */
+	private function numToString(BigInteger $number): string {
+		$output = '';
+		while ($number->isGreaterThan(0)) {
+			$previousNumber = clone $number;
+			$number = $number->dividedBy($this->dictionaryLength, RoundingMode::DOWN);
+			$digit = $previousNumber->mod($this->dictionaryLength);
+
+			$output .= $this->dictionary[(int)(string)$digit];
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Transforms a given string to a (big) number, based on the set dictionary.
+	 *
+	 * @param string $string
+	 *
+	 * @return \Brick\Math\BigInteger
+	 */
+	private function stringToNum(string $string): BigInteger {
+		$number = BigInteger::of(0);
+		foreach (str_split(strrev($string)) as $char) {
+			$number = $number->multipliedBy($this->dictionaryLength)->plus(array_search($char, $this->dictionary, false));
+		}
+
+		return $number;
+	}
+
+	/**
+	 * @param string $hex
+	 *
+	 * @return string
+	 */
+	protected function formatHex(string $hex): string {
+		$hex = str_pad($hex, 32, '0');
+		preg_match('/([a-f0-9]{8})([a-f0-9]{4})([a-f0-9]{4})([a-f0-9]{4})([a-f0-9]{12})/', $hex, $matches);
+		array_shift($matches);
+
+		return implode('-', $matches);
+	}
+
+}

--- a/src/Database/Type/ShortUuidType.php
+++ b/src/Database/Type/ShortUuidType.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Expose\Database\Type;
+
+use Cake\Core\Configure;
+use Cake\Core\Exception\Exception;
+use Cake\Database\DriverInterface;
+use Cake\Database\Type\BinaryUuidType;
+use Cake\Utility\Text;
+use Expose\Converter\ConverterInterface;
+use Expose\Converter\KeikoShort;
+
+/**
+ * Short Binary UUID type converter. Stored as binary16, displayed as char22.
+ *
+ * Use to convert binary uuid data between PHP and the database types.
+ */
+class ShortUuidType extends BinaryUuidType {
+
+	/**
+	 * Convert binary uuid data into the database format.
+	 *
+	 * Binary data is not altered before being inserted into the database.
+	 * As PDO will handle reading file handles.
+	 *
+	 * @param mixed $value The value to convert.
+	 * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
+	 * @return string|resource
+	 */
+	public function toDatabase($value, DriverInterface $driver) {
+		if (is_string($value)) {
+			$value = $this->lengthen($value);
+
+			return $this->convertStringToBinaryUuid($value);
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Generate a new short UUID.
+	 *
+	 * @return string A new primary key value.
+	 */
+	public function newId(): string {
+		return $this->shorten(Text::uuid());
+	}
+
+	/**
+	 * Convert short UUID into resource handles
+	 *
+	 * @param mixed $value The value to convert.
+	 * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
+	 * @return resource|string|null
+	 * @throws \Cake\Core\Exception\Exception
+	 */
+	public function toPHP($value, DriverInterface $driver) {
+		if ($value === null) {
+			return null;
+		}
+		if (is_string($value)) {
+			$value = $this->convertBinaryUuidToString($value);
+
+			return $this->shorten($value);
+		}
+		if (is_resource($value)) {
+			return $value;
+		}
+
+		throw new Exception(sprintf('Unable to convert %s into binary uuid.', gettype($value)));
+	}
+
+	/**
+	 * @param string $value
+	 *
+	 * @return string
+	 */
+	protected function shorten(string $value): string {
+		return $this->converter()->encode($value);
+	}
+
+	/**
+	 * @param string $value
+	 *
+	 * @return string
+	 */
+	protected function lengthen(string $value): string {
+		return $this->converter()->decode($value);
+	}
+
+	/**
+	 * @return \Expose\Converter\ConverterInterface
+	 */
+	protected function converter(): ConverterInterface {
+		$converter = Configure::read('Expose.converter');
+		if ($converter !== null && is_callable($converter)) {
+			return $converter();
+		}
+
+		if ($converter === null) {
+			$converter = KeikoShort::class;
+		}
+
+		return new $converter();
+	}
+
+}

--- a/src/Database/Type/ShortUuidType.php
+++ b/src/Database/Type/ShortUuidType.php
@@ -8,7 +8,7 @@ use Cake\Database\DriverInterface;
 use Cake\Database\Type\BinaryUuidType;
 use Cake\Utility\Text;
 use Expose\Converter\ConverterInterface;
-use Expose\Converter\KeikoShort;
+use Expose\Converter\Short;
 
 /**
  * Short Binary UUID type converter. Stored as binary16, displayed as char22.
@@ -98,7 +98,7 @@ class ShortUuidType extends BinaryUuidType {
 		}
 
 		if ($converter === null) {
-			$converter = KeikoShort::class;
+			$converter = Short::class;
 		}
 
 		return new $converter();

--- a/tests/TestCase/Converter/KeikoShortTest.php
+++ b/tests/TestCase/Converter/KeikoShortTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Expose\Test\TestCase\Converter;
+
+use Cake\TestSuite\TestCase;
+use Expose\Converter\KeikoShort;
+
+class KeikoShortTest extends TestCase {
+
+	/**
+	 * @var \Expose\Converter\ConverterInterface
+	 */
+	protected $converter;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->converter = new KeikoShort();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testEncode(): void {
+		$uuid = '806d0969-95b3-433b-976f-774611fdacbb';
+		$result = $this->converter->encode($uuid);
+
+		$this->assertSame('mavTAjNm4NVztDwh4gdSrQ', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDecode(): void {
+		$shortId = 'mavTAjNm4NVztDwh4gdSrQ';
+		$result = $this->converter->decode($shortId);
+
+		$this->assertSame('806d0969-95b3-433b-976f-774611fdacbb', $result);
+	}
+
+}

--- a/tests/TestCase/Converter/ShortTest.php
+++ b/tests/TestCase/Converter/ShortTest.php
@@ -3,12 +3,12 @@
 namespace Expose\Test\TestCase\Converter;
 
 use Cake\TestSuite\TestCase;
-use Expose\Converter\KeikoShort;
+use Expose\Converter\Short;
 
-class KeikoShortTest extends TestCase {
+class ShortTest extends TestCase {
 
 	/**
-	 * @var \Expose\Converter\KeikoShort
+	 * @var \Expose\Converter\Short
 	 */
 	protected $converter;
 
@@ -18,27 +18,27 @@ class KeikoShortTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->converter = new KeikoShort();
+		$this->converter = new Short();
 	}
 
 	/**
 	 * @return void
 	 */
 	public function testEncode(): void {
-		$uuid = '806d0969-95b3-433b-976f-774611fdacbb';
+		$uuid = '4e52c919-513e-4562-9248-7dd612c6c1ca';
 		$result = $this->converter->encode($uuid);
 
-		$this->assertSame('mavTAjNm4NVztDwh4gdSrQ', $result);
+		$this->assertSame('fpfyRTmt6XeE9ehEKZ5LwF', $result);
 	}
 
 	/**
 	 * @return void
 	 */
 	public function testDecode(): void {
-		$shortId = 'mavTAjNm4NVztDwh4gdSrQ';
+		$shortId = 'fpfyRTmt6XeE9ehEKZ5LwF';
 		$result = $this->converter->decode($shortId);
 
-		$this->assertSame('806d0969-95b3-433b-976f-774611fdacbb', $result);
+		$this->assertSame('4e52c919-513e-4562-9248-7dd612c6c1ca', $result);
 	}
 
 }

--- a/tests/TestCase/Database/Type/ShortUuidTypeTest.php
+++ b/tests/TestCase/Database/Type/ShortUuidTypeTest.php
@@ -45,7 +45,7 @@ class ShortUuidTypeTest extends TestCase {
 	 */
 	public function testNewId(): void {
 		$result = $this->type->newId();
-		$this->assertTrue(strlen($result) === 22, $result);
+		$this->assertWithinRange(21, strlen($result), 1, $result);
 	}
 
 	/**
@@ -71,6 +71,28 @@ class ShortUuidTypeTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testKeikoNewId(): void {
+		Configure::write('Expose.converter', KeikoShort::class);
+
+		$result = $this->type->newId();
+		$this->assertWithinRange(21, strlen($result), 1, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testKeikoToDatabase(): void {
+		Configure::write('Expose.converter', KeikoShort::class);
+
+		$shortId = 'mavTAjNm4NVztDwh4gdSrQ';
+		$result = $this->type->toDatabase($shortId, $this->driver);
+
+		$this->assertSame('806d096995b3433b976f774611fdacbb', bin2hex($result));
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testKeikoToPhp(): void {
 		Configure::write('Expose.converter', KeikoShort::class);
 
@@ -87,7 +109,7 @@ class ShortUuidTypeTest extends TestCase {
 		Configure::write('Expose.converter', $this->callable());
 
 		$result = $this->type->newId();
-		$this->assertTrue(strlen($result) === 22, $result);
+		$this->assertWithinRange(21, strlen($result), 1, $result);
 	}
 
 	/**

--- a/tests/TestCase/Database/Type/ShortUuidTypeTest.php
+++ b/tests/TestCase/Database/Type/ShortUuidTypeTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Expose\Test\TestCase\Database\Type;
+
+use Cake\Core\Configure;
+use Cake\Database\DriverInterface;
+use Cake\TestSuite\TestCase;
+use Expose\Converter\KeikoShort;
+use Expose\Database\Type\ShortUuidType;
+use Keiko\Uuid\Shortener\Dictionary;
+
+class ShortUuidTypeTest extends TestCase {
+
+	/**
+	 * @var \Expose\Database\Type\ShortUuidType
+	 */
+	protected $type;
+
+	/**
+	 * @var \Cake\Database\DriverInterface|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	protected $driver;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->driver = $this->getMockBuilder(DriverInterface::class)->getMock();
+		$this->type = new ShortUuidType();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		Configure::delete('Expose');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testNewId(): void {
+		$result = $this->type->newId();
+		$this->assertTrue(strlen($result) === 22, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testToDatabase(): void {
+		$shortId = 'mavTAjNm4NVztDwh4gdSrQ';
+		$result = $this->type->toDatabase($shortId, $this->driver);
+
+		$this->assertSame('806d096995b3433b976f774611fdacbb', bin2hex($result));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testToPhp(): void {
+		$binaryId = hex2bin('806d096995b3433b976f774611fdacbb');
+		$result = $this->type->toPHP($binaryId, $this->driver);
+
+		$this->assertSame('mavTAjNm4NVztDwh4gdSrQ', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testKeikoToPhp(): void {
+		Configure::write('Expose.converter', KeikoShort::class);
+
+		$binaryId = hex2bin('806d096995b3433b976f774611fdacbb');
+		$result = $this->type->toPHP($binaryId, $this->driver);
+
+		$this->assertSame('mavTAjNm4NVztDwh4gdSrQ', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCallableNewId(): void {
+		Configure::write('Expose.converter', $this->callable());
+
+		$result = $this->type->newId();
+		$this->assertTrue(strlen($result) === 22, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCallableToDatabase(): void {
+		Configure::write('Expose.converter', $this->callable());
+
+		$shortId = 'rfMuQ8HQ7CY0sc9avYqKu4';
+		$result = $this->type->toDatabase($shortId, $this->driver);
+
+		$this->assertSame('806d096995b3433b976f774611fdacbb', bin2hex($result));
+	}
+	/**
+	 * @return void
+	 */
+	public function testCallableToPhp(): void {
+		Configure::write('Expose.converter', $this->callable());
+
+		$binaryId = hex2bin('806d096995b3433b976f774611fdacbb');
+		$result = $this->type->toPHP($binaryId, $this->driver);
+
+		$this->assertSame('rfMuQ8HQ7CY0sc9avYqKu4', $result);
+	}
+
+	/**
+	 * @return callable
+	 */
+	protected function callable(): callable {
+		return function () {
+			return new KeikoShort(Dictionary::createAlphanumeric());
+		};
+	}
+
+}


### PR DESCRIPTION
https://github.com/dereuromark/cakephp-expose/issues/10

#### Shortening Converters
If you also want to shorten the resulting output UUID from 32 to 22 chars, go with `ShortUuidType` class which extends the binary one.
In this case you need to specify the type-map in your bootstrap:
```php
use Cake\Database\Type;

Type::map('binaryuuid', \Expose\Database\Type\ShortUuidType::class);
```
A UUID stored in the DB as `4e52c919-513e-4562-9248-7dd612c6c1ca` would then be displayed and
used as `fpfyRTmt6XeE9ehEKZ5LwF` for example.
This can be a bit more user-friendly as it is shorter and selectable with a double click in most browsers and apps.

Make sure to include the required composer dependencies as listed at the top of the converter class.
For the default one to work you need to run
```
composer require brick/math
```

You can select a different converter than the default `Short` one by configuring it through `Expose.converter`:
```php
// e.g. in your app.php
'Expose.converter' => \Expose\Converter\KeikoShort::class,
```
Or write your own one on plugin or app level using the given interface:
```php
namespace App\Converter;

use Expose\Converter\ConverterInterface;

class MyShort implements ConverterInterface {
    // implement the methods
}
```