### PR TITLE
Improve error handling, validation and code quality

### DIFF
--- a/src/Command/AddExposedFieldCommand.php
+++ b/src/Command/AddExposedFieldCommand.php
@@ -101,7 +101,16 @@ class AddExposedFieldCommand extends Command {
 			if ($this->migrationExists($migrationName, $this->migrationPath)) {
 				$io->abort('File already exists: ' . $migrationFilePath);
 			}
-			file_put_contents($migrationFilePath, $migrationContent);
+			if (!is_dir($this->migrationPath)) {
+				$io->abort('Migration path does not exist: ' . $this->migrationPath);
+			}
+			if (!is_writable($this->migrationPath)) {
+				$io->abort('Migration path is not writable: ' . $this->migrationPath);
+			}
+			$bytesWritten = @file_put_contents($migrationFilePath, $migrationContent);
+			if ($bytesWritten === false) {
+				$io->abort('Failed to write migration file: ' . $migrationFilePath);
+			}
 			$io->success('Migration file created. Now you can migrate your table(s) using `bin/cake migrations migrate`.');
 		} else {
 			$io->out('--- ' . $migrationName . '.php' . ' ---');

--- a/src/Controller/Component/SuperimposeComponent.php
+++ b/src/Controller/Component/SuperimposeComponent.php
@@ -16,7 +16,7 @@ class SuperimposeComponent extends Component {
 	 * @var array<string, mixed>
 	 */
 	protected array $_defaultConfig = [
-		'actions' => [],
+		'actions' => [], // Array of action names (strings) to apply superimposition to
 	];
 
 	/**

--- a/src/Converter/Short.php
+++ b/src/Converter/Short.php
@@ -109,7 +109,10 @@ class Short implements ConverterInterface {
 	 */
 	protected function formatHex(string $hex): string {
 		$hex = str_pad($hex, 32, '0');
-		preg_match('/([a-f0-9]{8})([a-f0-9]{4})([a-f0-9]{4})([a-f0-9]{4})([a-f0-9]{12})/', $hex, $matches);
+		$matched = preg_match('/([a-f0-9]{8})([a-f0-9]{4})([a-f0-9]{4})([a-f0-9]{4})([a-f0-9]{12})/', $hex, $matches);
+		if ($matched === 0) {
+			throw new RuntimeException('Invalid hex string format: ' . $hex);
+		}
 		array_shift($matches);
 
 		return implode('-', $matches);

--- a/src/Model/Behavior/ExposeBehavior.php
+++ b/src/Model/Behavior/ExposeBehavior.php
@@ -93,7 +93,6 @@ class ExposeBehavior extends Behavior {
 	 *
 	 * @param \Cake\ORM\Query\SelectQuery $query
 	 * @param string $uuid
-	 * @throws \InvalidArgumentException If the 'slug' key is missing in options
 	 * @return \Cake\ORM\Query\SelectQuery
 	 */
 	public function findExposed(SelectQuery $query, string $uuid): SelectQuery {
@@ -205,7 +204,9 @@ class ExposeBehavior extends Behavior {
 	protected function generateExposedField(string $field): string {
 		$fieldType = $this->_table->getSchema()->getColumnType($field);
 		if (!$fieldType) {
-			throw new RuntimeException('Cannot determine column type of field `' . $field . '`');
+			$schema = $this->_table->getSchema()->getColumn($field);
+
+			throw new RuntimeException('Cannot determine column type of field `' . $field . '`. Found type: ' . ($schema['type'] ?? 'unknown'));
 		}
 
 		$type = TypeFactory::build($fieldType);

--- a/src/Reverser/ReverseBinary.php
+++ b/src/Reverser/ReverseBinary.php
@@ -13,7 +13,7 @@ class ReverseBinary implements ReverseStrategyInterface {
 	 */
 	public function reverse(string $uuid): string {
 		if (strlen($uuid) !== 16) {
-			throw new RuntimeException();
+			throw new RuntimeException('Expected 16-byte binary UUID, got ' . strlen($uuid) . ' bytes');
 		}
 
 		return (string)(new BinaryUuidType())->toPHP($uuid, new Mysql());

--- a/src/Reverser/ReverseHex.php
+++ b/src/Reverser/ReverseHex.php
@@ -18,7 +18,7 @@ class ReverseHex implements ReverseStrategyInterface {
 			return (string)(new BinaryUuidType())->toPHP($binaryUuid, new Mysql());
 		}
 
-		throw new RuntimeException();
+		throw new RuntimeException('Expected hex format starting with "0x" and length 34, got: ' . $uuid);
 	}
 
 }

--- a/src/Reverser/ReverseShortened.php
+++ b/src/Reverser/ReverseShortened.php
@@ -12,7 +12,7 @@ class ReverseShortened implements ReverseStrategyInterface {
 	 */
 	public function reverse(string $uuid): string {
 		if (strlen($uuid) === 36) {
-			throw new RuntimeException();
+			throw new RuntimeException('Cannot reverse full-length UUID (36 chars), expected shortened format');
 		}
 
 		return ConverterFactory::getConverter()->decode($uuid);


### PR DESCRIPTION
## Summary
This PR improves error handling, validation, and code quality across multiple files by addressing issues #2, #3, #4 and several medium priority improvements.

## Changes Made

### Issue #2: Unsafe preg_match() Return Value Handling
**File:** `src/Converter/Short.php`

Added validation to check `preg_match()` return value before using the matches array:

```php
$matched = preg_match('/([a-f0-9]{8})([a-f0-9]{4})([a-f0-9]{4})([a-f0-9]{4})([a-f0-9]{12})/', $hex, $matches);
if ($matched === 0) {
    throw new RuntimeException('Invalid hex string format: ' . $hex);
}
```

**Impact:** Prevents potential bugs from malformed UUIDs causing invalid output.

---

### Issue #3: Vague Exception Messages in Reverser Classes
**Files:**
- `src/Reverser/ReverseBinary.php`
- `src/Reverser/ReverseHex.php`
- `src/Reverser/ReverseShortened.php`

Added descriptive error messages to all RuntimeException throws:

**Before:**
```php
throw new RuntimeException();
```

**After:**
```php
// ReverseBinary.php
throw new RuntimeException('Expected 16-byte binary UUID, got ' . strlen($uuid) . ' bytes');

// ReverseHex.php  
throw new RuntimeException('Expected hex format starting with "0x" and length 34, got: ' . $uuid);

// ReverseShortened.php
throw new RuntimeException('Cannot reverse full-length UUID (36 chars), expected shortened format');
```

**Impact:** Makes debugging significantly easier by providing context about what went wrong.

---

### Issue #4: Misleading PHPDoc in ExposeBehavior
**File:** `src/Model/Behavior/ExposeBehavior.php`

Removed incorrect `@throws \InvalidArgumentException If the 'slug' key is missing in options` from the `findExposed()` method docblock. The method signature clearly shows it accepts `string $uuid` directly, not an options array with a 'slug' key.

**Impact:** Improves code documentation accuracy.

---

### Medium #1: Input Validation for file_put_contents()
**File:** `src/Command/AddExposedFieldCommand.php`

Added validation before writing migration file:

```php
if (!is_dir($this->migrationPath)) {
    $io->abort('Migration path does not exist: ' . $this->migrationPath);
}
if (!is_writable($this->migrationPath)) {
    $io->abort('Migration path is not writable: ' . $this->migrationPath);
}
$bytesWritten = @file_put_contents($migrationFilePath, $migrationContent);
if ($bytesWritten === false) {
    $io->abort('Failed to write migration file: ' . $migrationFilePath);
}
```

**Impact:** Provides clear error messages when migration file creation fails.

---

### Medium #3: Incomplete Error Message in ExposeBehavior
**File:** `src/Model/Behavior/ExposeBehavior.php`

Enhanced error message to show the actual column type found:

```php
$schema = $this->_table->getSchema()->getColumn($field);
throw new RuntimeException('Cannot determine column type of field `' . $field . '`. Found type: ' . ($schema['type'] ?? 'unknown'));
```

**Impact:** Helps developers understand why a field type couldn't be determined.

---

### Medium #6: Type Documentation in SuperimposeComponent
**File:** `src/Controller/Component/SuperimposeComponent.php`

Added inline comment to clarify the expected type for the `actions` configuration:

```php
protected array $_defaultConfig = [
    'actions' => [], // Array of action names (strings) to apply superimposition to
];
```

**Impact:** Improves code readability and developer experience.

---

## Testing
✅ **All tests pass** (49 tests, 105 assertions, 1 skipped)  
✅ **PHPCS** passes with no violations

## Benefits
- 🐛 Prevents bugs from unchecked return values
- 🔍 Makes debugging much easier with descriptive error messages
- 📚 Improves code documentation accuracy
- ✅ Better error handling and validation throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)