### PR TITLE
Fix CakePHP 5.3 behavior method call deprecations

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,5 +7,3 @@ parameters:
 	ignoreErrors:
 		- identifier: missingType.iterableValue
 		- identifier: missingType.generics
-		- '#Call to an undefined method Cake\\ORM\\Table::getExposedKey\(\).#'
-		- '#PHPDoc tag @\w+ for \w+ \$table contains unresolvable type.#'

--- a/src/Command/AddExposedFieldCommand.php
+++ b/src/Command/AddExposedFieldCommand.php
@@ -51,8 +51,9 @@ class AddExposedFieldCommand extends Command {
 			$io->abort('You need to attach the Expose.Expose behavior to this model first (' . $table::class . '). Then we can create the migration for it.');
 		}
 
-		/** @phpstan-var \Cake\ORM\Table&\Expose\Model\Behavior\ExposeBehavior $table */
-		$field = $table->getExposedKey();
+		/** @var \Expose\Model\Behavior\ExposeBehavior $exposeBehavior */
+		$exposeBehavior = $table->getBehavior('Expose');
+		$field = $exposeBehavior->getExposedKey();
 		$fieldExists = $table->hasField($field);
 
 		if ($fieldExists) {
@@ -162,7 +163,7 @@ class AddExposedFieldCommand extends Command {
 
 	/**
 	 * @param string $migrationName
-	 * @param \Cake\ORM\Table&\Expose\Model\Behavior\ExposeBehavior $table
+	 * @param \Cake\ORM\Table $table
 	 * @param bool $containsRecords
 	 * @param bool $binary
 	 *
@@ -191,14 +192,16 @@ TXT;
 	}
 
 	/**
-	 * @param \Cake\ORM\Table&\Expose\Model\Behavior\ExposeBehavior $table
+	 * @param \Cake\ORM\Table $table
 	 * @param bool $containsRecords
 	 * @param bool $binary
 	 *
 	 * @return string
 	 */
 	protected function generateOperations(Table $table, bool $containsRecords, bool $binary): string {
-		$field = $table->getExposedKey();
+		/** @var \Expose\Model\Behavior\ExposeBehavior $exposeBehavior */
+		$exposeBehavior = $table->getBehavior('Expose');
+		$field = $exposeBehavior->getExposedKey();
 		$tableName = $table->getTable();
 		$null = $containsRecords ? 'true' : 'false';
 		$type = $binary ? 'binary' : 'uuid';
@@ -229,12 +232,14 @@ TXT;
 	}
 
 	/**
-	 * @param \Cake\ORM\Table&\Expose\Model\Behavior\ExposeBehavior $table
+	 * @param \Cake\ORM\Table $table
 	 *
 	 * @return string
 	 */
 	protected function generateUpdateOperation(Table $table): string {
-		$field = $table->getExposedKey();
+		/** @var \Expose\Model\Behavior\ExposeBehavior $exposeBehavior */
+		$exposeBehavior = $table->getBehavior('Expose');
+		$field = $exposeBehavior->getExposedKey();
 		$tableName = $table->getTable();
 
 		$operations = <<<TXT

--- a/src/Command/PopulateExposedFieldCommand.php
+++ b/src/Command/PopulateExposedFieldCommand.php
@@ -34,13 +34,14 @@ class PopulateExposedFieldCommand extends Command {
 			$io->abort('Model missing');
 		}
 
-		/** @var \Cake\ORM\Table&\Expose\Model\Behavior\ExposeBehavior $table */
 		$table = $this->getTableLocator()->get($model);
 
-		$field = $table->getExposedKey();
+		/** @var \Expose\Model\Behavior\ExposeBehavior $exposeBehavior */
+		$exposeBehavior = $table->getBehavior('Expose');
+		$field = $exposeBehavior->getExposedKey();
 		$io->out('Populating ' . $model . ' `' . $field . '` field ...');
 
-		$count = $table->initExposedField();
+		$count = $exposeBehavior->initExposedField();
 
 		$io->success('Populated ' . $count . ' records. Nothing else left.');
 

--- a/tests/TestCase/Model/Behavior/ExposeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ExposeBehaviorTest.php
@@ -110,7 +110,9 @@ class ExposeBehaviorTest extends TestCase {
 
 		$uuid = $user->uuid;
 
-		$field = $this->Users->getExposedKey();
+		/** @var \Expose\Model\Behavior\ExposeBehavior $exposeBehavior */
+		$exposeBehavior = $this->Users->getBehavior('Expose');
+		$field = $exposeBehavior->getExposedKey();
 		$this->assertSame('uuid', $field);
 
 		/** @var \TestApp\Model\Entity\User $result */
@@ -118,7 +120,7 @@ class ExposeBehaviorTest extends TestCase {
 
 		$this->assertSame($user->id, $result->id);
 
-		$field = $this->Users->getExposedKey(true);
+		$field = $exposeBehavior->getExposedKey(true);
 		$this->assertSame('Users.uuid', $field);
 	}
 
@@ -130,7 +132,9 @@ class ExposeBehaviorTest extends TestCase {
 
 		$uuid = $user->uuid;
 
-		$field = $this->Users->getExposedKey();
+		/** @var \Expose\Model\Behavior\ExposeBehavior $exposeBehavior */
+		$exposeBehavior = $this->Users->getBehavior('Expose');
+		$field = $exposeBehavior->getExposedKey();
 		$this->assertSame('uuid', $field);
 
 		/** @var \TestApp\Model\Entity\User $result */
@@ -138,7 +142,7 @@ class ExposeBehaviorTest extends TestCase {
 
 		$this->assertSame($user->id, $result->id);
 
-		$field = $this->Users->getExposedKey(true);
+		$field = $exposeBehavior->getExposedKey(true);
 		$this->assertSame('Users.uuid', $field);
 	}
 
@@ -197,11 +201,11 @@ class ExposeBehaviorTest extends TestCase {
 	 */
 	public function testInitExposedField(): void {
 		$customFieldRecordsTable = TableRegistry::getTableLocator()->get('ExistingRecords');
-
-		/** @var \Cake\ORM\Table&\Expose\Model\Behavior\ExposeBehavior $customFieldRecordsTable */
 		$customFieldRecordsTable->addBehavior('Expose.Expose');
 
-		$count = $customFieldRecordsTable->initExposedField();
+		/** @var \Expose\Model\Behavior\ExposeBehavior $exposeBehavior */
+		$exposeBehavior = $customFieldRecordsTable->getBehavior('Expose');
+		$count = $exposeBehavior->initExposedField();
 		$this->assertSame(1, $count);
 
 		$records = $customFieldRecordsTable->find()->find('list', ...['valueField' => 'uuid'])->toArray();
@@ -237,14 +241,14 @@ class ExposeBehaviorTest extends TestCase {
 	 */
 	public function testInitExposedFieldWithCustomPrimaryKey(): void {
 		$customPrimaryKeyTable = TableRegistry::getTableLocator()->get('CustomPrimaryKeyRecords');
-
-		/** @var \Cake\ORM\Table&\Expose\Model\Behavior\ExposeBehavior $customPrimaryKeyTable */
 		$customPrimaryKeyTable->addBehavior('Expose.Expose');
 
 		$primaryKey = $customPrimaryKeyTable->getPrimaryKey();
 		$this->assertSame('code', $primaryKey);
 
-		$count = $customPrimaryKeyTable->initExposedField();
+		/** @var \Expose\Model\Behavior\ExposeBehavior $exposeBehavior */
+		$exposeBehavior = $customPrimaryKeyTable->getBehavior('Expose');
+		$count = $exposeBehavior->initExposedField();
 		$this->assertSame(2, $count);
 
 		$records = $customPrimaryKeyTable->find()->toArray();


### PR DESCRIPTION
## Summary
- Use `$table->getBehavior('Expose')->methodName()` instead of calling behavior methods directly on the table instance
- Updated AddExposedFieldCommand to use getBehavior() for getExposedKey()
- Updated PopulateExposedFieldCommand to use getBehavior() for getExposedKey() and initExposedField()
- Updated tests to follow the same pattern
- Removed phpstan ignores that are no longer needed

This fixes the CakePHP 5.3 deprecation: "Calling behavior methods on the table instance is deprecated"