### PR TITLE
Tighten Reverser error handling and hex input validation

### DIFF
--- a/src/Reverser/ReverseHex.php
+++ b/src/Reverser/ReverseHex.php
@@ -12,13 +12,16 @@ class ReverseHex implements ReverseStrategyInterface {
 	 * @inheritDoc
 	 */
 	public function reverse(string $uuid): string {
-		if (strlen($uuid) === 34 && strpos($uuid, '0x') === 0) {
-			$binaryUuid = hex2bin(substr($uuid, 2));
-
-			return (string)(new BinaryUuidType())->toPHP($binaryUuid, new Mysql());
+		if (strlen($uuid) !== 34 || !str_starts_with($uuid, '0x')) {
+			throw new RuntimeException('Expected hex format starting with "0x" and length 34, got: ' . $uuid);
 		}
 
-		throw new RuntimeException('Expected hex format starting with "0x" and length 34, got: ' . $uuid);
+		$binaryUuid = @hex2bin(substr($uuid, 2));
+		if ($binaryUuid === false || strlen($binaryUuid) !== 16) {
+			throw new RuntimeException('Invalid hex content in UUID: ' . $uuid);
+		}
+
+		return (string)(new BinaryUuidType())->toPHP($binaryUuid, new Mysql());
 	}
 
 }

--- a/src/Reverser/Reverser.php
+++ b/src/Reverser/Reverser.php
@@ -2,14 +2,14 @@
 
 namespace Expose\Reverser;
 
-use Exception;
+use RuntimeException;
 
 class Reverser {
 
 	/**
-	 * @var array<string>
+	 * @var array<class-string<\Expose\Reverser\ReverseStrategyInterface>>
 	 */
-	protected array $stategies = [
+	protected array $strategies = [
 		ReverseBinary::class,
 		ReverseHex::class,
 		ReverseShortened::class,
@@ -21,14 +21,11 @@ class Reverser {
 	 * @return string|null
 	 */
 	public function reverse(string $uuid): ?string {
-		foreach ($this->stategies as $stategy) {
+		foreach ($this->strategies as $strategy) {
 			try {
-				/** @var \Expose\Reverser\ReverseStrategyInterface $object */
-				$object = new $stategy();
-
-				return $object->reverse($uuid);
-			} catch (Exception $exception) {
-				// Do nothing
+				return (new $strategy())->reverse($uuid);
+			} catch (RuntimeException $exception) {
+				// Strategy could not handle this input format, try next.
 			}
 		}
 

--- a/tests/TestCase/Reverser/ReverserTest.php
+++ b/tests/TestCase/Reverser/ReverserTest.php
@@ -51,4 +51,23 @@ class ReverserTest extends TestCase {
 		$this->assertSame('f7ac0123-a938-4e80-840e-efe892051332', $result);
 	}
 
+	/**
+	 * No strategy should match a clearly invalid input; null is returned without leaking errors.
+	 *
+	 * @return void
+	 */
+	public function testReverseUnreversableReturnsNull(): void {
+		$this->assertNull($this->reverser->reverse('not-a-uuid'));
+	}
+
+	/**
+	 * A 34-char string with the expected `0x` prefix but non-hex bytes must not be silently accepted.
+	 *
+	 * @return void
+	 */
+	public function testReverseHexWithInvalidHexContentReturnsNull(): void {
+		$invalid = '0x' . str_repeat('z', 32);
+		$this->assertNull($this->reverser->reverse($invalid));
+	}
+
 }


### PR DESCRIPTION
## Summary

Three small but related cleanups to the UUID reverser pipeline. Total ~50 LOC across three files.

### Rename `$stategies` / `$stategy` to `$strategies` / `$strategy`

`src/Reverser/Reverser.php` had a typo on the protected property name and the loop variable. Although protected, the misspelling was visible on the API surface — any subclass overriding the strategy list would have had to repeat it. Easier to fix now than once dependents accumulate. Docblock array shape also tightened to `array<class-string<ReverseStrategyInterface>>` so PHPStan can verify additions.

### Narrow `catch (Exception)` to `catch (RuntimeException)` in `Reverser::reverse()`

`src/Reverser/Reverser.php:23-33` previously caught every exception and silently moved on. The `ReverseStrategyInterface` contract only documents `RuntimeException` for format mismatches — `TypeError`, database errors, and programming bugs inside strategies were being masked, leaving admin users with a bare "no result" and no diagnostic trail. The recently-added descriptive `RuntimeException` messages for length and prefix mismatches still flow through the strategy chain (so a binary input keeps falling through to `ReverseBinary` etc.), while real bugs now propagate where they belong.

### Validate `hex2bin()` failure in `ReverseHex::reverse()`

`src/Reverser/ReverseHex.php` previously passed `hex2bin()`'s `string|false` return straight into `BinaryUuidType::toPHP()`. A 34-char input with the `0x` prefix but non-hex bytes after it emitted a silent PHP warning, the `false` coerced to an empty string, and the downstream conversion produced a misleading result. The check now throws a descriptive `RuntimeException` that the `Reverser` loop can pass through to the next strategy. Also swaps the `strpos` prefix check for `str_starts_with()` (PHP 8.2 minimum is already in composer.json).

### Tests

Two new test cases cover the failure paths so they cannot regress:
- `testReverseUnreversableReturnsNull` — clearly invalid input returns `null`.
- `testReverseHexWithInvalidHexContentReturnsNull` — `0x` prefix with non-hex bytes returns `null` (no warning, no misleading output).

PHPUnit 51/51 green, PHPStan clean, PHPCS clean.
