### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/expose.pot
+++ b/resources/locales/expose.pot
@@ -1,0 +1,22 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 02:49+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "Enter the UUID you want to reverse"
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+

--- a/templates/Admin/Expose/index.php
+++ b/templates/Admin/Expose/index.php
@@ -28,14 +28,14 @@
 
 		<?php echo $this->Form->create(null, ['type' => 'file']);?>
 		<fieldset>
-			<legend><?php echo __('Enter the UUID you want to reverse');?></legend>
+			<legend><?php echo __d('expose', 'Enter the UUID you want to reverse');?></legend>
 			<?php
 			echo $this->Form->control('uuid', []);
 			//echo $this->Form->control('shortened', ['type' => 'checkbox', 'label' => 'This UUID is shortened']);
 			echo $this->Form->control('file', ['type' => 'file', 'label' => '.bin file']);
 			?>
 		</fieldset>
-		<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+		<?php echo $this->Form->submit(__d('expose', 'Submit')); echo $this->Form->end();?>
 
 	</div>
 


### PR DESCRIPTION
## Summary

- Convert the 2 `__()` calls in the Admin/Expose template to `__d('expose', ...)` so plugin strings live in their own domain.
- Add `resources/locales/expose.pot` (2 unique msgids) generated via `bin/cake i18n extract` so language packs can be derived from a stable POT.

## Why

Plugin strings were landing in the host app's `default` domain. Anyone translating the host app would have ended up translating this plugin's UI under their own domain — and shipping a translated language pack with the plugin was effectively impossible.

## Verification (local)

- phpunit: 51 / 51 (13 pre-existing notices, 1 skipped — unrelated to this change)
- phpstan: no errors
- phpcs: clean