### PR TITLE
Fix Short leading-zero bug and clarify identifier docs

### DIFF
--- a/docs/Motivation.md
+++ b/docs/Motivation.md
@@ -33,3 +33,14 @@ Further issues with only UUID as primary key:
 Issues with mixing across tables - some primary keys as UUID and others as AIID:
 - Easy to mess things up (e.g. some foreign_key now has to be varchar to allow both the int and the string)
 - Less flexible in general of adding functionality on top. Keeping always primary key one type allows here for easier future additions.
+
+### Why UUIDv4 (and not v7, ULID, NanoID, Snowflake, KSUID, ...)
+The exposed field's job is to be a public lookup key that does **not** leak information about the underlying record. That rules out every time-ordered identifier:
+
+- **UUIDv7, ULID, KSUID, Snowflake** all embed a high-precision timestamp in their leading bits. Anyone holding two such IDs can determine which record was created first, estimate the gap between them, and approximate when each was created. With a handful of samples, they can also estimate how many records you create per minute. That is exactly the side-channel this plugin is designed to close.
+- **NanoID** is random by design and would be acceptable on the randomness axis, but it's a *generator*, not an *encoding* - it produces fresh strings rather than reversibly encoding an existing 128-bit value. Since this plugin shortens an existing UUID column (so the DB column type stays a real `uuid`/`binary(16)`), there is no functional gap a NanoID alphabet would fill that the `Short` converter's URL-safe dictionary doesn't already cover at the same 22-char output length.
+- **Hashids / Sqids** encode the primary key itself, which is precisely the approach this plugin moved away from (see "Why not Hash IDs" above).
+
+So UUIDv4 is not a default-of-convenience here, it's a deliberate choice: 122 bits of pure randomness, no embedded timestamp, no embedded counter, native DB type support across MySQL/Postgres/SQLite.
+
+If your project values time-ordering (e.g. for cursor pagination or natural insertion order in the DB) more than it values not leaking creation time, UUIDv7 *is* usable with this plugin via the `KeikoShort` converter - the built-in `Short` converter intentionally does not support v7. See the converter docs for details.

--- a/docs/Motivation.md
+++ b/docs/Motivation.md
@@ -43,4 +43,4 @@ The exposed field's job is to be a public lookup key that does **not** leak info
 
 So UUIDv4 is not a default-of-convenience here, it's a deliberate choice: 122 bits of pure randomness, no embedded timestamp, no embedded counter, native DB type support across MySQL/Postgres/SQLite.
 
-If your project values time-ordering (e.g. for cursor pagination or natural insertion order in the DB) more than it values not leaking creation time, UUIDv7 *is* usable with this plugin via the `KeikoShort` converter - the built-in `Short` converter intentionally does not support v7. See the converter docs for details.
+If your project would rather have time-ordered IDs and is OK with the timestamp leakage - e.g. you only expose IDs to authenticated users who would already be able to infer ordering, or you need cursor pagination over the exposed key - UUIDv7 still works with this plugin: both built-in converters round-trip v7 correctly. You just need to swap the UUID generator the plugin uses (see "Using a different UUID generator" in the converter docs).

--- a/docs/README.md
+++ b/docs/README.md
@@ -268,8 +268,14 @@ $result = ConverterFactory::getConverter()->encode($value);
 $result = ConverterFactory::getConverter()->decode($value);
 ```
 
-Also note: Some more modern UUIDs might require a special shortener.
-E.g. v7 currently is only supported by `KeikoShort` converter, not built-in one.
+#### Using UUIDv7 (or other modern UUID flavors)
+This plugin defaults to UUIDv4 because the exposed field is meant to be a public lookup key that does not leak record-creation order or timing. UUIDv7 (and ULID, KSUID, Snowflake, ...) embed a high-precision timestamp in their leading bits, so any two such IDs reveal which record came first and roughly when - see [Motivation: Why UUIDv4](Motivation.md#why-uuidv4-and-not-v7-ulid-nanoid-snowflake-ksuid-) for the full trade-off.
+
+If your project values time-ordering more than that obfuscation, UUIDv7 works with this plugin, but only via the `KeikoShort` converter:
+```php
+'Expose.converter' => \Expose\Converter\KeikoShort::class,
+```
+The built-in `Short` converter intentionally does not support v7 - that's a design choice, not a missing feature.
 
 ### Backend
 The plugin comes with an optional and small admin backend to reverse UUIDs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -271,11 +271,7 @@ $result = ConverterFactory::getConverter()->decode($value);
 #### Using UUIDv7 (or other modern UUID flavors)
 This plugin defaults to UUIDv4 because the exposed field is meant to be a public lookup key that does not leak record-creation order or timing. UUIDv7 (and ULID, KSUID, Snowflake, ...) embed a high-precision timestamp in their leading bits, so any two such IDs reveal which record came first and roughly when - see [Motivation: Why UUIDv4](Motivation.md#why-uuidv4-and-not-v7-ulid-nanoid-snowflake-ksuid-) for the full trade-off.
 
-If your project values time-ordering more than that obfuscation, UUIDv7 works with this plugin, but only via the `KeikoShort` converter:
-```php
-'Expose.converter' => \Expose\Converter\KeikoShort::class,
-```
-The built-in `Short` converter intentionally does not support v7 - that's a design choice, not a missing feature.
+If you would rather have time-ordered IDs and accept that leakage (e.g. for cursor pagination), both built-in converters round-trip UUIDv7 correctly - just swap the generator as shown in "Using a different UUID generator" above.
 
 ### Backend
 The plugin comes with an optional and small admin backend to reverse UUIDs.

--- a/src/Converter/Short.php
+++ b/src/Converter/Short.php
@@ -9,9 +9,9 @@ use RuntimeException;
 /**
  * Make sure to include the required dependency `brick/math`.
  *
- * UUIDv7 is deliberately not supported here: this plugin's exposed field is meant to be a public
- * lookup key that does not leak record creation order/time, and v7 embeds a timestamp in its
- * leading bits. Use the `KeikoShort` converter if you accept that trade-off. See docs/Motivation.md.
+ * Works on any UUID version (v4 is the default the plugin generates). Note that v6/v7 embed
+ * a timestamp in their leading bits, which leaks record creation order/time - see
+ * docs/Motivation.md for the rationale behind preferring v4 for exposed fields.
  */
 class Short implements ConverterInterface {
 
@@ -110,7 +110,7 @@ class Short implements ConverterInterface {
 	 * @return string
 	 */
 	protected function formatHex(string $hex): string {
-		$hex = str_pad($hex, 32, '0');
+		$hex = str_pad($hex, 32, '0', STR_PAD_LEFT);
 		$matched = preg_match('/([a-f0-9]{8})([a-f0-9]{4})([a-f0-9]{4})([a-f0-9]{4})([a-f0-9]{12})/', $hex, $matches);
 		if ($matched === 0) {
 			throw new RuntimeException('Invalid hex string format: ' . $hex);

--- a/src/Converter/Short.php
+++ b/src/Converter/Short.php
@@ -9,7 +9,9 @@ use RuntimeException;
 /**
  * Make sure to include the required dependency `brick/math`.
  *
- * @note Does not support UUID v7 at this point.
+ * UUIDv7 is deliberately not supported here: this plugin's exposed field is meant to be a public
+ * lookup key that does not leak record creation order/time, and v7 embeds a timestamp in its
+ * leading bits. Use the `KeikoShort` converter if you accept that trade-off. See docs/Motivation.md.
  */
 class Short implements ConverterInterface {
 

--- a/tests/TestCase/Converter/ShortTest.php
+++ b/tests/TestCase/Converter/ShortTest.php
@@ -58,12 +58,25 @@ class ShortTest extends TestCase {
 	 * @return void
 	 */
 	public function testUuid7(): void {
-		$this->skipIf(true, 'Not supported right now');
+		$this->skipIf(!method_exists(Uuid::class, 'uuid7'), 'Only ramsey/uuid 4.7+');
 
 		$uuidOriginal = Uuid::uuid7()->toString();
 		$uuidShort = $this->converter->encode($uuidOriginal);
 		$uuidDecoded = $this->converter->decode($uuidShort);
 		$this->assertSame($uuidOriginal, $uuidDecoded);
+	}
+
+	/**
+	 * Regression: hex values with leading zero nibbles must round-trip.
+	 * BigInteger drops most-significant zeros, so decode must left-pad to 32 chars.
+	 *
+	 * @return void
+	 */
+	public function testEncodeDecodeWithLeadingZero(): void {
+		$uuid = '0e52c919-513e-4562-9248-7dd612c6c1ca';
+		$encoded = $this->converter->encode($uuid);
+		$decoded = $this->converter->decode($encoded);
+		$this->assertSame($uuid, $decoded);
 	}
 
 }


### PR DESCRIPTION
Resolves https://github.com/dereuromark/cakephp-expose/issues/15

## Summary

- **Fix**: `Short::formatHex()` used `str_pad($hex, 32, '0')` which defaults to `STR_PAD_RIGHT`. `BigInteger::toBase(16)` strips most-significant zeros, so decode needs LEFT-padding. As a result the converter silently corrupted ~6% of UUIDv4 values (any beginning with hex `0`) and 100% of UUIDv7 values - v7's timestamp prefix is `01...` for the next several thousand years, so it always lost the leading zero on decode. One-line fix: pass `STR_PAD_LEFT`.
- **Tests**: unskipped the existing `testUuid7` (was `skipIf(true, 'Not supported right now')`, now runs and passes) and added `testEncodeDecodeWithLeadingZero` covering the v4 leading-zero case.
- **Docs**: added a "Why UUIDv4 (and not v7 / ULID / NanoID / Snowflake / KSUID / ...)" section to `docs/Motivation.md` explaining why time-ordered IDs don't fit the plugin's "exposed field must not leak record order/time" goal, and why NanoID is a generator (not an encoding) so it duplicates what `Short` already does. Promoted the previously-buried "UUIDv7 needs KeikoShort" footnote in `docs/README.md` into its own subsection - now updated to reflect that both built-in converters round-trip v7 correctly after the fix.
- **Class docblock**: `Short` no longer claims to "deliberately" not support v7; instead it links to the Motivation rationale for defaulting to v4.

## Why this matters

The bug only surfaces when a v4 UUID happens to begin with hex `0` (1-in-16 chance) - so it would have been a rare, mysterious "this one record isn't findable by its exposed key" report rather than something that fails fast. The new test catches it.

The `testUuid7` skip annotation said *"Not supported right now"* which read like a TODO; before this PR I had assumed it was a deliberate design choice and almost shipped docs claiming so. Investigating the actual code revealed the bug.